### PR TITLE
Fix Errors

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,4 +2,4 @@ name: KillStreaks
 author: [Infernus101, Fris]
 main: specter\killstreaks\Main
 version: 1.2.0
-api: [3.0.0-ALPHA9, 3.0.0-ALPHA10]
+api: [3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11, 3.0.0-ALPHA12]

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -9,9 +9,9 @@ streak-lose-message: "Oh no! you lost your streak of {streak}!"
 ## {player} will be replaced by player's name
 ## {streak} will be replaced by player's streak
 5: 
-  tell {player} {streak} kill streak!
-  say {player} is on a {streak} killStreak!
+  - "tell {player} {streak} kill streak!"
+  - "say {player} is on a {streak} killStreak!"
 10: 
-  tell {player} {streak} kill streak!
-  say {player} is on a {streak} killStreak!
+  - "tell {player} {streak} kill streak!"
+  - "say {player} is on a {streak} killStreak!"
 ...

--- a/src/specter/killstreaks/PlayerEvents.php
+++ b/src/specter/killstreaks/PlayerEvents.php
@@ -47,8 +47,10 @@ class PlayerEvents implements Listener {
                     if(($kstreak = $this->getPlugin()->getStreak($killer)) != 0){
                         $killer->sendMessage(str_replace("{streak}", "{$kstreak}", $this->getPlugin()->config->get("on-streak-message")));
                         $commands = $this->getPlugin()->config->get($kstreak);
-                        foreach($commands as $command){
-                            $this->getPlugin()->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{streak}", $kstreak, str_replace("{player}", $killer->getName(), $command)));
+                        if(is_array($commands) || is_object($commands)){
+                            foreach($commands as $command){
+                                $this->getPlugin()->getServer()->dispatchCommand(new ConsoleCommandSender(), str_replace("{streak}", $kstreak, str_replace("{player}", $killer->getName(), $command)));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The plugin actually still works as it is, but throws type errors every time a player dies. This fixes the `Invalid argument supplied for foreach()` type errors. 